### PR TITLE
Fix CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 sudo: false
-dist: trusty
+dist: xenial
 
 install: echo "Don't let Travis CI execute './gradlew assemble' by default"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ install: echo "Don't let Travis CI execute './gradlew assemble' by default"
 
 matrix:
   include:
-  - jdk: oraclejdk8
-  - jdk: oraclejdk9
+  - jdk: openjdk8
+  - jdk: openjdk9
   - jdk: openjdk10
   - jdk: openjdk11
   - jdk: openjdk12


### PR DESCRIPTION
Currently the CI build is broken (https://travis-ci.org/github/vavr-io/vavr-test/builds/760872304) on Open JDK 10, 11, ,12, 13 because Travis failed to download OpenJDK from the [Trusty build environment](https://docs.travis-ci.com/user/reference/trusty/). This PR mitigates the problem by upgrading to [Xenial build environment](https://docs.travis-ci.com/user/reference/xenial/) and fixes the [new failures on Xenial](https://travis-ci.com/github/mincong-h/vavr-test/builds/219191919) by changing the Oracle JDK 8, 9 by Open JDK 8, 9.